### PR TITLE
Add a makefile that compiles and installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+default:
+	@echo "Usage:"
+	@echo "    build - Create the hr binary"
+	@# Path taken from https://en.wikipedia.org/wiki/Unix_filesystem
+	@echo "    install - Create the hr binary and move it to /usr/local/bin"
+	@echo "    clean - Delete any files created by make"
+	
+build:
+	mkdir bin
+	test -x /usr/bin/gcc && gcc -o bin/hr hr.c || "Please install gcc"
+	@echo "Built successfully. Binary at `pwd`/bin/hc" 
+
+install: build
+	test ! -e /usr/local/bin/hr || (echo "File exists at /usr/local/bin/hr. Cannot continue" && false)
+	mv bin/hr /usr/local/bin/hr && rmdir bin
+	@echo "Installed successfuly"
+
+clean:
+	# We ignore whether or not the clean was successfull, as it's possible
+	# the build is in a state we don't know. Therefore, delete everything 
+	# and start again
+	rm -r bin

--- a/README.txt
+++ b/README.txt
@@ -13,5 +13,11 @@ https://github.com/LuRsT/hr
 You can find HalosGhost's version of hr here:
 https://github.com/HalosGhost/.bin/blob/master/src/hr.c
 
+INSTALLATION
+------------
+
+    (from the git repo)
+    $ sudo make install
+
 This program is released into the public domain without any warranty.
 


### PR DESCRIPTION
At the moment, it's a little unclear what you're supposed to do to
get "hr" transformed from a block of C into a binary that you can use.
This commit adds a make file that compiles (and optionally installs)
the binary so it's easier to use.

Closes #1 
